### PR TITLE
Restrict TSA verify options

### DIFF
--- a/internal/crypto/cms/signed_test.go
+++ b/internal/crypto/cms/signed_test.go
@@ -54,8 +54,8 @@ func TestVerifySignedData(t *testing.T) {
 	if err != nil {
 		t.Fatal("ParseSignedData.Verify() error =", err)
 	}
-	if !reflect.DeepEqual(verifiedSigners, signed.Signers) {
-		t.Fatalf("ParseSignedData.Verify() = %v, want %v", verifiedSigners, signed.Signers)
+	if !reflect.DeepEqual(verifiedSigners, signed.Certificates[:1]) {
+		t.Fatalf("ParseSignedData.Verify() = %v, want %v", verifiedSigners, signed.Certificates[:1])
 	}
 }
 

--- a/signature/jws/signer.go
+++ b/signature/jws/signer.go
@@ -28,6 +28,13 @@ type Signer struct {
 	// certChain contains the X.509 public key certificate or certificate chain corresponding
 	// to the key used to generate the signature.
 	certChain [][]byte
+
+	// TSA is the TimeStamp Authority to timestamp the resulted signature if present.
+	TSA timestamp.Timestamper
+
+	// TSARoots is the set of trusted root certificates for verifying the fetched timestamp
+	// signature. If nil, the system roots or the platform verifier are used.
+	TSARoots *x509.CertPool
 }
 
 // NewSigner creates a signer with the recommended signing method and a signing key bundled
@@ -155,7 +162,7 @@ func timestampSignature(ctx context.Context, sig string, tsa timestamp.Timestamp
 	tokenBytes := resp.TokenBytes()
 
 	// verify the timestamp signature
-	if _, err := verifyTimestamp(decodedSig, tokenBytes, opts); err != nil {
+	if _, err := verifyTimestamp(decodedSig, tokenBytes, opts.Roots); err != nil {
 		return nil, err
 	}
 

--- a/signature/jws/signer_test.go
+++ b/signature/jws/signer_test.go
@@ -66,6 +66,10 @@ func TestSignWithTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("timestamptest.NewTSA() error = %v", err)
 	}
+	s.TSA = tsa
+	tsaRoots := x509.NewCertPool()
+	tsaRoots.AddCert(tsa.Certificate())
+	s.TSARoots = tsaRoots
 
 	// sign content
 	ctx := context.Background()

--- a/signature/jws/verifier_test.go
+++ b/signature/jws/verifier_test.go
@@ -76,6 +76,10 @@ func TestVerifyWithTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("timestamptest.NewTSA() error = %v", err)
 	}
+	s.TSA = tsa
+	tsaRoots := x509.NewCertPool()
+	tsaRoots.AddCert(tsa.Certificate())
+	s.TSARoots = tsaRoots
 
 	// sign content
 	ctx := context.Background()
@@ -99,7 +103,7 @@ func TestVerifyWithTimestamp(t *testing.T) {
 	}
 
 	// verify again with certificate trusted
-	v.TSAVerifyOptions.Roots = sOpts.TSAVerifyOptions.Roots
+	v.TSARoots = tsaRoots
 	got, err := v.Verify(ctx, sig, vOpts)
 	if err != nil {
 		t.Fatalf("Verify() error = %v", err)


### PR DESCRIPTION
All verification options, except configurating the root certificate pool, are hidden from the timestamp token verifiers.

Resolves #16.